### PR TITLE
Upgrade json dependency from 1.8.1 to 1.8.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
       gemoji (~> 2.0)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0)
-    json (1.8.1)
+    json (1.8.6)
     kramdown (1.10.0)
     liquid (3.0.6)
     listen (3.0.6)


### PR DESCRIPTION
I had to change it to get on with `bundle install`.

I'm not very familiar with `bundler` so I didn't run `bundle update` at first. 
Creating this PR is making things easier with setting up this theme for newbies like me.

Fresh instance of `ubuntu:xenial`.
`ruby 2.3.1p112`
`jekyll 3.0.3`
`Bundler version 1.14.3`