### PR TITLE
add ability to have noindex included on a page/pos

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,6 +16,10 @@ layout: compress
     <meta content="{{ site.share.fb_appid }}" property="fb:app_id">
     <meta content="{{ site.title }}" property="og:site_name">
 
+    {% if page.noindex %}
+      <meta name="robots" content="noindex">
+    {% endif %}
+
     {% if page.title %}
       <meta content="{{ page.title }}" property="og:title">
       <meta content="article" property="og:type">


### PR DESCRIPTION
If a page or post has noindex defined, a meta tag will be included instructing robots to not index this page/post. This can be useful for old and/or out of date information for example.