### PR TITLE
fix pagination issue with last page link

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@ layout: default
         {% endif %}
       {% endfor %}
 
-      <li><a href="/page{{ paginator.total_pages }}/">Last</a></li>
+      <li><a href="/page/{{ paginator.total_pages }}/">Last</a></li>
 
       {% if paginator.next_page %}
         <li><a href="{{ paginator.next_page_path | prepend: site.baseurl | replace: '//', '/' }}">&raquo;</a></li>


### PR DESCRIPTION
The "Last" page link was linking to `/page4/` for me instead of `/page/4/` due to a missing slash.