### PR TITLE
Prevent HTML compression during local development

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -53,3 +53,5 @@ compress_html:
   clippings: all
   comments: ["<!-- ", " -->"]
   endings: all
+  ignore:
+    envs: ['development']


### PR DESCRIPTION
This can be fairly useful during local development.