### PR TITLE
Remove Google+ share button

### DIFF
--- a/_includes/share-page.html
+++ b/_includes/share-page.html
@@ -5,10 +5,6 @@
   <a href="https://twitter.com/share" class="twitter-share-button" data-via="{{ site.share.twitter_username }}">Tweet</a>
   <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 
-  <!-- Google + -->
-  <div class="g-plus" data-action="share" data-annotation="bubble"></div>
-  <script src="https://apis.google.com/js/platform.js" async defer></script>
-
   <!-- Facebook -->
   <div class="fb-share-button" data-href="{{ site.url }}{{ page.url }}" data-layout="button_count" style="position: relative; top: -8px; left: 3px;"></div>
 </div>


### PR DESCRIPTION
Google+ is dead. (and it has been during whole period of it's existence in case you didn't know :joy:)

https://www.cnet.com/news/google-reportedly-exposed-data-of-hundreds-of-thousands-of-google-users/
https://duckduckgo.com/?q=google%2B+shut+down&t=ffab