### PR TITLE
Update jekyll version to 3.7.4 due to security vulnerability CVE-2018-17567

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ GEM
     github-pages (186)
       activesupport (= 4.2.10)
       github-pages-health-check (= 1.8.1)
-      jekyll (= 3.7.3)
+      jekyll (= 3.7.4)
       jekyll-avatar (= 0.5.0)
       jekyll-coffeescript (= 1.1.1)
       jekyll-commonmark-ghpages (= 0.1.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jekyll (3.7.3)
+    jekyll (3.7.4)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)


### PR DESCRIPTION
Update jekyll version to 3.7.4 due to security vulnerability [CVE-2018-17567](https://nvd.nist.gov/vuln/detail/CVE-2018-17567)

> Jekyll through 3.6.2, 3.7.x through 3.7.3, and 3.8.x through 3.8.3 allows attackers to access arbitrary files by specifying a symlink in the "include" key in the "_config.yml" file.