### PR TITLE
Remove highlight section in main.css

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -65,9 +65,7 @@ div.content pre {
   font-size: 12px;
   border: none;
 }
-div.content .highlight {
-	background: #333333;
-}
+
 footer {
   border-top: 1px solid #F7F1F1;
   width: 100%;


### PR DESCRIPTION
Changes in background color parameter value of "pre" do nothing . This is because the background color of "pre" is overwritten by highlight section. For this reason, "highlight" section is removed.